### PR TITLE
Adding Superlinter as Github action

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Super-linter
-        uses: github/super-linter/super-linter/slim@v5  # no c#,rust,dotenv,pwsh,armttk
+        uses: github/super-linter/super-linter/slim@v6  # no c#,rust,dotenv,pwsh,armttk
         env:
           # To report GitHub Actions status checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Super-linter
-        uses: github/super-linter/super-linter/slim@v6  # no c#,rust,dotenv,pwsh,armttk
+        uses: super-linter/super-linter@v6.4.1  # x-release-please-version
         env:
           # To report GitHub Actions status checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,6 +8,7 @@ on:  # yamllint disable-line rule:truthy
       - dev
       - TEMPLATE
   pull_request:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,8 +1,8 @@
-name: nextflow linting
+name: Lint
 # This workflow is triggered on pushes and PRs to the repository to ensure
 # valid code is being contributed. 
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - dev
@@ -11,17 +11,52 @@ on:
   release:
     types: [published]
 
+permissions: { }
+
 jobs:
-  groovy-lint:
+  build:
+    name: Lint
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - name: Super-linter
+        uses: github/super-linter/super-linter/slim@v5  # no c#,rust,dotenv,pwsh,armttk
+        env:
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_BASH: true
+          VALIDATE_GROOVY: true
+          VALIDATE_JSON: true
+          VALIDATE_MARKDOWN: true
+          VALIDATE_PERL: true
+          VALIDATE_PYTHON_FLAKE8: true
+          VALIDATE_R: true
+          VALIDATE_YAML: true
 
-      - name: Install groovy lint
-        run: npm install -g npm-groovy-lint
+# jobs:
+#   groovy-lint:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
 
-      - name: Run groovy lint check
-        run: npm-groovy-lint --failon error ${GITHUB_WORKSPACE}
+#       - uses: actions/setup-node@v4
 
+#       - name: Install groovy lint
+#         run: npm install -g npm-groovy-lint
+
+#       - name: Run groovy lint check
+#         run: npm-groovy-lint --failon error ${GITHUB_WORKSPACE}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # FooDMe 2
 
-This pipeline performs processing of mitochondrial amplicon data to profile the composition of eukaryotic taxa. 
+This pipeline performs processing of mitochondrial amplicon data to profile the composition of eukaryotic taxa.
 
-Typical applications are in the analysis of food products, animal feed or seed materials. 
+Typical applications are in the analysis of food products, animal feed or seed materials.
 
-## Documentation 
+## Documentation
 
 1. [What happens in this pipeline?](docs/pipeline.md)
 2. [Installation and configuration](docs/installation.md)

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -44,7 +44,7 @@ the `--help` command line option can be found in lib/WorkflowMain.groovy. Likewi
 
 By design, modules should provide software as either conda environment or container. See existing modules for how that can be achieved.
 
-```
+```bash
 conda 'bioconda::multiqc=1.19'
 container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
     'https://depot.galaxyproject.org/singularity/multiqc:1.19--pyhdfd78af_0' :
@@ -53,9 +53,11 @@ container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity
 
 What does this do? Basically, if conda is enabled as software provider, the specified package will be installed into a process-specific environment. Else, a container is pulled - where the source depends on whether you run Docker (native Docker image) or e.g. Singularity (dedicated singularity image).
 
-We normally use Bioconda as the source for software packages; either directly via conda or through containers that are built directly from Bioconda. You'll note that each Bioconda package lists the matching Biocontainer link. For convenience, it is recommended to provide links to the native Biocontainer Docker container as well as the singularity version hosted by the Galaxy team under [https://depot.galaxyproject.org/singularity/](https://depot.galaxyproject.org/singularity/).
+We normally use Bioconda as the source for software packages; either directly via conda or through containers that are built directly from Bioconda. You'll note that each Bioconda package lists the matching Biocontainer link.
+For convenience, it is recommended to provide links to the native Biocontainer Docker container as well as the singularity version hosted by the Galaxy team under [https://depot.galaxyproject.org/singularity/](https://depot.galaxyproject.org/singularity/).
 
-There are two situations where this approach will not work (directly). One is the use of multiple software packages in one pipeline process. While this can be done for conda-based provisioning by simply providing the name of multiple packages, it does not work for pre-built containers. Instead, you need a so-called "mulled" container; which are built from two or more Bioconda packages - described [here](https://github.com/BioContainers/multi-package-containers). Sometimes you can be lucky and find existing mulled containers that do what you need. Else - see the description above.
+There are two situations where this approach will not work (directly). One is the use of multiple software packages in one pipeline process. While this can be done for conda-based provisioning by simply providing the name of multiple packages, it does not work for pre-built containers.
+Instead, you need a so-called "mulled" container; which are built from two or more Bioconda packages - described [here](https://github.com/BioContainers/multi-package-containers). Sometimes you can be lucky and find existing mulled containers that do what you need. Else - see the description above.
 
 If mulling containers is not an option, you can also refer to github actions and have the pipeline built its own mulled container. For that, see the section about Docker below.
 
@@ -65,13 +67,16 @@ Github supports the automatic execution of specific tasks on code branches, such
 
 ### Docker containers
 
-In order to automatically push Docker containers, you must add your docker username and API token as secrets to your repository (DOCKERHUB_USERNAME and DOCKERHUB_TOKEN). Secrets can be created under Settings/Secrets and Variables/Actions. Of course, you also need to have an account on Dockerhub and generate a permanent token.  The relevant workflow actions are included in `dot_github/workflows`. These will read the `Dockerfile` from the root of this repository, import environment.yml (if you wish to install conda packages into the container), build the whole thing and push the container to an appropriate dockerhub repository
+In order to automatically push Docker containers, you must add your docker username and API token as secrets to your repository (DOCKERHUB_USERNAME and DOCKERHUB_TOKEN). Secrets can be created under Settings/Secrets and Variables/Actions.
+Of course, you also need to have an account on Dockerhub and generate a permanent token.  The relevant workflow actions are included in `dot_github/workflows`.
+These will read the `Dockerfile` from the root of this repository, import environment.yml (if you wish to install conda packages into the container), build the whole thing and push the container to an appropriate dockerhub repository
 
 ### Linting
 
-Nextflow does not have a dedicated linting tool. However, since most of nextflow is actually Groovy, the groovy linting suite works just fine, I find. Linting is set up as an automatic workflow for every push to the TEMPLATE and dev branch as well as pull requests. You may wish to run this stand-alone also, before you commit your code. I would strongly recommend setting this up in a [conda](https://github.com/conda-forge/miniforge) environment, but it should also work on your *nix system directly (albeit with some minor pitfalls re: java version).
+Nextflow does not have a dedicated linting tool. However, since most of nextflow is actually Groovy, the groovy linting suite works just fine, I find. Linting is set up as an automatic workflow for every push to the TEMPLATE and dev branch as well as pull requests.
+You may wish to run this stand-alone also, before you commit your code. I would strongly recommend setting this up in a [conda](https://github.com/conda-forge/miniforge) environment, but it should also work on your *nix system directly (albeit with some minor pitfalls re: java version).
 
-```
+```bash
 conda create -n nf-lint nodejs openjdk=17.0.10
 conda activate nf-lint
 npm install -g npm-groovy-lint
@@ -79,7 +84,7 @@ npm install -g npm-groovy-lint
 
 In your pipeline directory, you can check all the files in one go as follows:
 
-```
+```bash
 npm-groovy-lint
 ```
 
@@ -91,19 +96,19 @@ Make sure that the local linting produces *no* messages (info, warning, error) o
 
 1. Create a new repository and use this template
 
-![](../images/github_template.png)
+![template](../images/github_template.png)
 
 2. Checkout the new repository
 
 After checking out the repo, create a branch "dev" as well as "main"
 
-```
+```bash
 git branch dev
 git branch main
 ```
 With these branches created, switch to the dev branch and start developing.
 
-```
+```bash
 git checkout dev
 ```
 
@@ -131,11 +136,13 @@ git checkout dev
 
 It is very much recommended to implement a simple test suite for your pipeline.
 
-A default test profile is already included with this code base - you simply have to update the inputs. These inputs should consist of a highly reduced data set that can be processes in a very short amount of time. An example would be short read data from a small section of the genome only (which you could, for example, extract from a BAM file using coordinates). You get the idea. We try to keep test data in a [shared repository](https://github.com/marchoeppner/nf-testdata) - you might find something you can use in there, or you could add your own data set. Remember, git has a hard-limit of 50MB for individual files.
+A default test profile is already included with this code base - you simply have to update the inputs.
+These inputs should consist of a highly reduced data set that can be processes in a very short amount of time. An example would be short read data from a small section of the genome only (which you could, for example, extract from a BAM file using coordinates).
+You get the idea. We try to keep test data in a [shared repository](https://github.com/marchoeppner/nf-testdata) - you might find something you can use in there, or you could add your own data set. Remember, git has a hard-limit of 50MB for individual files.
 
 To run the test, the syntax would be:
 
-```
+```bash
 nextflow run my/pipeline -profile standard,test
 ```
 
@@ -143,4 +150,4 @@ Here, standard refers to the default site configuration ('standard') - change it
 
 ## Sending report emails
 
-This template is set up to send the final QC report via Email (--email you@gmail.com). This requires for sendmail to be configured on the executing node/computer.
+This template is set up to send the final QC report via Email (`--email you@email.com`). This requires for sendmail to be configured on the executing node/computer.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,10 +1,10 @@
 # Developer's guide
 
-This document is a brief overview of how to use this code base. Some understanding of Nextflow and how it implements DSL2 is assumed. 
+This document is a brief overview of how to use this code base. Some understanding of Nextflow and how it implements DSL2 is assumed.
 
 ## Editor
 
-I personally recommend [Microsoft Visual Studio Code](https://code.visualstudio.com/download) for working on nextflow pipelines. It's free and comes with a variety of free extensions to support your work. 
+I personally recommend [Microsoft Visual Studio Code](https://code.visualstudio.com/download) for working on nextflow pipelines. It's free and comes with a variety of free extensions to support your work.
 
 This template specifically is set up to work with the following VS extensions:
 
@@ -21,7 +21,7 @@ This pipeline base is organized in the following way:
 * `main.nf` - entry point into the pipeline, imports the core workflow from `workflow/<pipeline>.nf`
 * `workflow/<pipeline.nf>` - the actual core logic of the pipeline; imports sub-workflows from `subworkflow/<sub>.nf`
 * `subworkflow/<sub>.nf` - a self-contained processing chain that is part of the larger workflow (e.g. read alignment and dedup in a WGS calling workflow)
-* `modules/<module>.nf` - A command line tool/call that can be imported into a (sub)workflow. 
+* `modules/<module>.nf` - A command line tool/call that can be imported into a (sub)workflow.
 
 ## Config files
 
@@ -31,18 +31,18 @@ Some aspects of this code base are controlled by config files. These are:
 
 /conf/resources.config - here you can put some pipeline-internal options, like locations of reference files and the like (assuming you use a generic base directory with fixed folder structure or S3 buckets)
 
-/conf/base.config - this file sets the computing specifications for different types of processes. 
+/conf/base.config - this file sets the computing specifications for different types of processes.
 
-/conf/lsh.config - this is an example of a site-specific config file (set as "standard" profile in nextflow.config), in which you can provide information about your compute environment. Make sure to create a new profile for it too. 
+/conf/lsh.config - this is an example of a site-specific config file (set as "standard" profile in nextflow.config), in which you can provide information about your compute environment. Make sure to create a new profile for it too.
 
 ## Groovy libraries
 
-This pipeline imports a few functions into the nextflow files from lib/ - mostly to keep the actual pipeline code a bit cleaner/more readable. For example, 
-the `--help` command line option can be found in lib/WorkflowMain.groovy. Likewise, you could use this approach to do some basic validation of your inputs etc. 
+This pipeline imports a few functions into the nextflow files from lib/ - mostly to keep the actual pipeline code a bit cleaner/more readable. For example,
+the `--help` command line option can be found in lib/WorkflowMain.groovy. Likewise, you could use this approach to do some basic validation of your inputs etc.
 
 ## Bioconda/biocontainers
 
-By design, modules should provide software as either conda environment or container. See existing modules for how that can be achieved. 
+By design, modules should provide software as either conda environment or container. See existing modules for how that can be achieved.
 
 ```
 conda 'bioconda::multiqc=1.19'
@@ -55,21 +55,21 @@ What does this do? Basically, if conda is enabled as software provider, the spec
 
 We normally use Bioconda as the source for software packages; either directly via conda or through containers that are built directly from Bioconda. You'll note that each Bioconda package lists the matching Biocontainer link. For convenience, it is recommended to provide links to the native Biocontainer Docker container as well as the singularity version hosted by the Galaxy team under [https://depot.galaxyproject.org/singularity/](https://depot.galaxyproject.org/singularity/).
 
-There are two situations where this approach will not work (directly). One is the use of multiple software packages in one pipeline process. While this can be done for conda-based provisioning by simply providing the name of multiple packages, it does not work for pre-built containers. Instead, you need a so-called "mulled" container; which are built from two or more Bioconda packages - described [here](https://github.com/BioContainers/multi-package-containers). Sometimes you can be lucky and find existing mulled containers that do what you need. Else - see the description above. 
+There are two situations where this approach will not work (directly). One is the use of multiple software packages in one pipeline process. While this can be done for conda-based provisioning by simply providing the name of multiple packages, it does not work for pre-built containers. Instead, you need a so-called "mulled" container; which are built from two or more Bioconda packages - described [here](https://github.com/BioContainers/multi-package-containers). Sometimes you can be lucky and find existing mulled containers that do what you need. Else - see the description above.
 
-If mulling containers is not an option, you can also refer to github actions and have the pipeline built its own mulled container. For that, see the section about Docker below. 
+If mulling containers is not an option, you can also refer to github actions and have the pipeline built its own mulled container. For that, see the section about Docker below.
 
 ## Github workflows
 
-Github supports the automatic execution of specific tasks on code branches, such as the automatic linting of the code base or building and pushing of Docker containers. To add github workflows to your repository, place them into the sub-directory `.github/workflows`. 
+Github supports the automatic execution of specific tasks on code branches, such as the automatic linting of the code base or building and pushing of Docker containers. To add github workflows to your repository, place them into the sub-directory `.github/workflows`.
 
 ### Docker containers
 
-In order to automatically push Docker containers, you must add your docker username and API token as secrets to your repository (DOCKERHUB_USERNAME and DOCKERHUB_TOKEN). Secrets can be created under Settings/Secrets and Variables/Actions. Of course, you also need to have an account on Dockerhub and generate a permanent token.  The relevant workflow actions are included in `dot_github/workflows`. These will read the `Dockerfile` from the root of this repository, import environment.yml (if you wish to install conda packages into the container), build the whole thing and push the container to an appropriate dockerhub repository 
+In order to automatically push Docker containers, you must add your docker username and API token as secrets to your repository (DOCKERHUB_USERNAME and DOCKERHUB_TOKEN). Secrets can be created under Settings/Secrets and Variables/Actions. Of course, you also need to have an account on Dockerhub and generate a permanent token.  The relevant workflow actions are included in `dot_github/workflows`. These will read the `Dockerfile` from the root of this repository, import environment.yml (if you wish to install conda packages into the container), build the whole thing and push the container to an appropriate dockerhub repository
 
 ### Linting
 
-Nextflow does not have a dedicated linting tool. However, since most of nextflow is actually Groovy, the groovy linting suite works just fine, I find. Linting is set up as an automatic workflow for every push to the TEMPLATE and dev branch as well as pull requests. You may wish to run this stand-alone also, before you commit your code. I would strongly recommend setting this up in a [conda](https://github.com/conda-forge/miniforge) environment, but it should also work on your *nix system directly (albeit with some minor pitfalls re: java version). 
+Nextflow does not have a dedicated linting tool. However, since most of nextflow is actually Groovy, the groovy linting suite works just fine, I find. Linting is set up as an automatic workflow for every push to the TEMPLATE and dev branch as well as pull requests. You may wish to run this stand-alone also, before you commit your code. I would strongly recommend setting this up in a [conda](https://github.com/conda-forge/miniforge) environment, but it should also work on your *nix system directly (albeit with some minor pitfalls re: java version).
 
 ```
 conda create -n nf-lint nodejs openjdk=17.0.10
@@ -85,11 +85,11 @@ npm-groovy-lint
 
 You'll note that some obvious errors/warnings are omitted. This behavior is controlled by the settings in .groovylintrc [documentation](https://www.npmjs.com/package/npm-groovy-lint), included with this template. If you need to switch on some stuff, just add it the config file - and vice-versa.
 
-Make sure that the local linting produces *no* messages (info, warning, error) or the automatic action will throw an error and flag the commit as "failed linting". This is not a deal breaker, but in principle should be fixed before merging into the `main` branch. 
+Make sure that the local linting produces *no* messages (info, warning, error) or the automatic action will throw an error and flag the commit as "failed linting". This is not a deal breaker, but in principle should be fixed before merging into the `main` branch.
 
 ## How to start
 
-1. Create a new repository and use this template 
+1. Create a new repository and use this template
 
 ![](../images/github_template.png)
 
@@ -114,24 +114,24 @@ git checkout dev
 - If you want to provision a pipeline-specific Docker container
   - rename dot_github to .github
   - Create a dockerhub project for this pipeline
-  - Update the github actions to the name of the dockerhub project 
+  - Update the github actions to the name of the dockerhub project
 
   IMPORTANT: When you rename files in a git project, use `git mv`, not plain `mv` to avoid breaking the built-in file tracking of your git repo!
 
-4. Outline your primary workflow logic in `workflow/<pipeline.nf>` 
+4. Outline your primary workflow logic in `workflow/<pipeline.nf>`
 
 5. Start outlining your subworkflows, if any, in `subworkflows/<subworkflow.nf>`
 
 6. Build all the necessary modules in `modules/`, using `modules/fastp/main.nf` as a template
    - Use a subfolder for each software package and folders therein for sub-functions of a given tool (e.g. samtools)
    - Each module should include a `conda/container` statement to specify which software package is to be used
-   - Each module should collect information on the software version(s) of the tools used - see existing modules for examples. 
+   - Each module should collect information on the software version(s) of the tools used - see existing modules for examples.
 
 ## How to test
 
-It is very much recommended to implement a simple test suite for your pipeline. 
+It is very much recommended to implement a simple test suite for your pipeline.
 
-A default test profile is already included with this code base - you simply have to update the inputs. These inputs should consist of a highly reduced data set that can be processes in a very short amount of time. An example would be short read data from a small section of the genome only (which you could, for example, extract from a BAM file using coordinates). You get the idea. We try to keep test data in a [shared repository](https://github.com/marchoeppner/nf-testdata) - you might find something you can use in there, or you could add your own data set. Remember, git has a hard-limit of 50MB for individual files. 
+A default test profile is already included with this code base - you simply have to update the inputs. These inputs should consist of a highly reduced data set that can be processes in a very short amount of time. An example would be short read data from a small section of the genome only (which you could, for example, extract from a BAM file using coordinates). You get the idea. We try to keep test data in a [shared repository](https://github.com/marchoeppner/nf-testdata) - you might find something you can use in there, or you could add your own data set. Remember, git has a hard-limit of 50MB for individual files.
 
 To run the test, the syntax would be:
 
@@ -139,8 +139,8 @@ To run the test, the syntax would be:
 nextflow run my/pipeline -profile standard,test
 ```
 
-Here, standard refers to the default site configuration ('standard') - change it if you need to run this pipeline under a different profile. 
+Here, standard refers to the default site configuration ('standard') - change it if you need to run this pipeline under a different profile.
 
 ## Sending report emails
 
-This template is set up to send the final QC report via Email (--email you@gmail.com). This requires for sendmail to be configured on the executing node/computer. 
+This template is set up to send the final QC report via Email (--email you@gmail.com). This requires for sendmail to be configured on the executing node/computer.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ This pipeline expects Nextflow version 23.10.1, available [here](https://github.
 
 ## Software provisioning
 
-This pipeline is set up to work with a range of software provisioning technologies - no need to manually install packages. 
+This pipeline is set up to work with a range of software provisioning technologies - no need to manually install packages.
 
 You can choose one of the following options:
 
@@ -34,11 +34,11 @@ nextflow run bio-raum/FooDMe2 -profile singularity \\
 --reference_base /path/to/references
 ```
 
-where `/path/to/references` could be something like `/data/pipelines/references` or whatever is most appropriate on your system. If you have already added your own profile to our [configuration](https://github.com/marchoeppner/nf-configs) repository, then the `--reference_base` option does not need to be set from the command line. 
+where `/path/to/references` could be something like `/data/pipelines/references` or whatever is most appropriate on your system. If you have already added your own profile to our [configuration](https://github.com/marchoeppner/nf-configs) repository, then the `--reference_base` option does not need to be set from the command line.
 
 If you do not have singularity on your system, you can also specify docker, podman or conda for software provisioning - see the [usage information](usage.md).
 
-The path specified with `--reference_base` can then be given to the pipeline during normal execution as `--reference_base` (unless you already have set it as part of your site-specific config file). Please note that the build process will create a pipeline-specific subfolder (`FooDMe2`) that must not be given as part of the `--reference_base` argument. Euktaxpro is part of a collection of pipelines that use a shared reference directory and it will choose the appropriate subfolder by itself. 
+The path specified with `--reference_base` can then be given to the pipeline during normal execution as `--reference_base` (unless you already have set it as part of your site-specific config file). Please note that the build process will create a pipeline-specific subfolder (`FooDMe2`) that must not be given as part of the `--reference_base` argument. Euktaxpro is part of a collection of pipelines that use a shared reference directory and it will choose the appropriate subfolder by itself.
 
 ## Site-specific config file
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ The pipeline comes with simple pre-set profiles for all of these as described [h
 
 This pipeline requires locally stored references from the [Midori](https://www.reference-midori.info/) project. To build these, do:
 
-```
+```bash
 nextflow run bio-raum/FooDMe2 -profile singularity \\
 --build_references \\
 --run_name build_refs \\
@@ -38,7 +38,8 @@ where `/path/to/references` could be something like `/data/pipelines/references`
 
 If you do not have singularity on your system, you can also specify docker, podman or conda for software provisioning - see the [usage information](usage.md).
 
-The path specified with `--reference_base` can then be given to the pipeline during normal execution as `--reference_base` (unless you already have set it as part of your site-specific config file). Please note that the build process will create a pipeline-specific subfolder (`FooDMe2`) that must not be given as part of the `--reference_base` argument. Euktaxpro is part of a collection of pipelines that use a shared reference directory and it will choose the appropriate subfolder by itself.
+The path specified with `--reference_base` can then be given to the pipeline during normal execution as `--reference_base` (unless you already have set it as part of your site-specific config file).
+Please note that the build process will create a pipeline-specific subfolder (`FooDMe2`) that must not be given as part of the `--reference_base` argument. Euktaxpro is part of a collection of pipelines that use a shared reference directory and it will choose the appropriate subfolder by itself.
 
 ## Site-specific config file
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -1,4 +1,4 @@
-# Outputs 
+# Outputs
 
 ## Reports
 
@@ -12,15 +12,15 @@ sample  reads   hits
 SampleA 12678   Sus scrofa:75.5,Bos taurus:24.5
 ```
 
-where hits are a sorted list of identified taxa and their respective percentages of the total read count. If a sample has multiple separate OTU hits for the same taxon, this taxon will be summed up across all matching OTUs to remove noise from the result. 
+where hits are a sorted list of identified taxa and their respective percentages of the total read count. If a sample has multiple separate OTU hits for the same taxon, this taxon will be summed up across all matching OTUs to remove noise from the result.
 
 - `name_of_pipeline_run`.taxonomy_by_sample.json: A JSON formatted data structure for downstream computational processing. The following structure is used:
 
 ```JSON
 [
-    { 
+    {
       "sample": "SampleA",
-      "hits": [ 
+      "hits": [
         { "taxon": "Bos taurus", "reads": 1234 },
         { "taxon": "Sus scrofa", "reads": 6543 }
       ],
@@ -28,7 +28,7 @@ where hits are a sorted list of identified taxa and their respective percentages
     },
     {
       "sample": "SampleB",
-      "hits": [ 
+      "hits": [
         { "taxon": "Ovis aries", "reads": 246 },
         { "taxon": "Rangifer tarandus", "reads": 753 }
       ],
@@ -37,7 +37,7 @@ where hits are a sorted list of identified taxa and their respective percentages
 ]
 ```
 
-The data in this file is largely unfiltered and it might be useful to compute percentages and remove any taxa that fall below a threshold and/or collapse hits from the same taxon into one result, based on your specific use case. 
+The data in this file is largely unfiltered and it might be useful to compute percentages and remove any taxa that fall below a threshold and/or collapse hits from the same taxon into one result, based on your specific use case.
 
 </details>
 
@@ -63,7 +63,7 @@ The data in this file is largely unfiltered and it might be useful to compute pe
 <details markdown=1>
 <summary>vsearch</summary>
 
-This folder contains the various intermediate processing outputs and is mostly there for debugging purposes. 
+This folder contains the various intermediate processing outputs and is mostly there for debugging purposes.
 
 </details>
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,3 +1,3 @@
 # Pipeline structure
 
-![](../images/pipeline_dag.png)
+![dag](../images/pipeline_dag.png)

--- a/docs/software.md
+++ b/docs/software.md
@@ -17,6 +17,6 @@ Version 1.3.3, doi: 10.1186/s12859-019-2854-x, [PubMed](https://pubmed.ncbi.nlm.
 ## References
 
 **Midori**
-References used by this pipeline are obtained from the [Midori](https://www.reference-midori.info/) database, based on GenBank release 2023-12-17. 
+References used by this pipeline are obtained from the [Midori](https://www.reference-midori.info/) database, based on GenBank release 2023-12-17.
 
 Version 2023-12, 17, doi: 10.1093/bioinformatics/bty454, [Pubmed](https://pubmed.ncbi.nlm.nih.gov/29878054/)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,5 +2,6 @@
 
 ## Cutadapt: Multiple hits from the same species/genus per sample
 
-If you find that the results are "exploded" into many redundant hits (i.e. from the same species or genus), chances are that something has gone wrong during primer site removal, resulting in many near-redundant OTUs being formed. If you elected to use Cutadapt for primer site removal, check if it would perhaps be appropriate to also set the option `--cutadapt_trim_3p`, i.e. in such cases where your target is so small that it is contained within a single read. Cutadapt will otherwise fail to properly clean the primer sites, resulting in sequences that cannot be fully merged into unique OTUs later on.
-
+If you find that the results are "exploded" into many redundant hits (i.e. from the same species or genus), chances are that something has gone wrong during primer site removal, resulting in many near-redundant OTUs being formed.
+If you elected to use Cutadapt for primer site removal, check if it would perhaps be appropriate to also set the option `--cutadapt_trim_3p`, i.e. in such cases where your target is so small that it is contained within a single read.
+Cutadapt will otherwise fail to properly clean the primer sites, resulting in sequences that cannot be fully merged into unique OTUs later on.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,5 +2,5 @@
 
 ## Cutadapt: Multiple hits from the same species/genus per sample
 
-If you find that the results are "exploded" into many redundant hits (i.e. from the same species or genus), chances are that something has gone wrong during primer site removal, resulting in many near-redundant OTUs being formed. If you elected to use Cutadapt for primer site removal, check if it would perhaps be appropriate to also set the option `--cutadapt_trim_3p`, i.e. in such cases where your target is so small that it is contained within a single read. Cutadapt will otherwise fail to properly clean the primer sites, resulting in sequences that cannot be fully merged into unique OTUs later on. 
+If you find that the results are "exploded" into many redundant hits (i.e. from the same species or genus), chances are that something has gone wrong during primer site removal, resulting in many near-redundant OTUs being formed. If you elected to use Cutadapt for primer site removal, check if it would perhaps be appropriate to also set the option `--cutadapt_trim_3p`, i.e. in such cases where your target is so small that it is contained within a single read. Cutadapt will otherwise fail to properly clean the primer sites, resulting in sequences that cannot be fully merged into unique OTUs later on.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # Usage information
 
-This is not a full release. Please note that some things may not work as intended yet. 
+This is not a full release. Please note that some things may not work as intended yet.
 
 [Running the pipeline](#running-the-pipeline)
 
@@ -14,7 +14,7 @@ This is not a full release. Please note that some things may not work as intende
 
 ## Running the pipeline
 
-Please see our [installation guide](installation.md) to learn how to set up this pipeline first. 
+Please see our [installation guide](installation.md) to learn how to set up this pipeline first.
 
 A basic execution of the pipeline looks as follows:
 
@@ -27,26 +27,26 @@ nextflow run bio-raum/FooDMe2 -profile singularity --input samples.csv \\
 --primer_set par64_illumina
 ```
 
-where `path_to_references` corresponds to the location in which you have [installed](installation.md) the pipeline references (this can be omitted to trigger an on-the-fly temporary installation, but is not recommended in production). 
+where `path_to_references` corresponds to the location in which you have [installed](installation.md) the pipeline references (this can be omitted to trigger an on-the-fly temporary installation, but is not recommended in production).
 
 In this example, the pipeline will assume it runs on a single computer with the singularity container engine available. Available options to provision software are:
 
 `-profile singularity`
 
-`-profile docker` 
+`-profile docker`
 
-`-profile podman` 
+`-profile podman`
 
-`-profile conda` 
+`-profile conda`
 
 b) with a site-specific config file
 
 ```bash
 nextflow run bio-raum/FooDMe2 -profile lsh --input samples.csv \\
---run_name pipeline-test 
+--run_name pipeline-test
 ```
 
-In this example, both `--reference_base` and the choice of software provisioning are already set in the local configuration `lsh` and don't have to provided as command line argument. In addition, you can set additional site-specific parameters, such as your local resource manager, node configuration (CPU, RAM, wall time), desired cache directory for the configured package/container software etc. 
+In this example, both `--reference_base` and the choice of software provisioning are already set in the local configuration `lsh` and don't have to provided as command line argument. In addition, you can set additional site-specific parameters, such as your local resource manager, node configuration (CPU, RAM, wall time), desired cache directory for the configured package/container software etc.
 
 ## Specifying pipeline version
 
@@ -69,7 +69,7 @@ sample  platform    fq1 fq2
 S100    ILLUMINA    /path/to/S100_R1.fastq.gz   /path/to/S100_R2.fastq.gz
 ```
 
-If the pipeline sees more than one set of reads for a given sample ID, it will concatenate them automatically at the appropriate time. 
+If the pipeline sees more than one set of reads for a given sample ID, it will concatenate them automatically at the appropriate time.
 
 Allowed platforms are:
 
@@ -92,9 +92,9 @@ Alternatively, you can specify your own primers as described in the following.
 
 ### `--primers_txt ` [ default = null ]
 
-If you wish to use a set of primers not already configured for this pipeline, you can provide it with this option. You will also have to specify which mitochondrial gene this primer set is targeting using the `--gene` option described elsewhere. 
+If you wish to use a set of primers not already configured for this pipeline, you can provide it with this option. You will also have to specify which mitochondrial gene this primer set is targeting using the `--gene` option described elsewhere.
 
-This text file will be read by [Ptrimmer](https://pubmed.ncbi.nlm.nih.gov/31077131/) to remove PCR primers from the adapter-clipped reads. Please see the Ptrimmer [documentation](https://github.com/DMU-lilab/pTrimmer) on how to create such a config file or look at the [example](../assets/ptrimmer/par64_illumina.txt) included with this pipeline. 
+This text file will be read by [Ptrimmer](https://pubmed.ncbi.nlm.nih.gov/31077131/) to remove PCR primers from the adapter-clipped reads. Please see the Ptrimmer [documentation](https://github.com/DMU-lilab/pTrimmer) on how to create such a config file or look at the [example](../assets/ptrimmer/par64_illumina.txt) included with this pipeline.
 
 Briefly, the file is a simple text format with each row representing one pair of primers, as follows:
 
@@ -102,7 +102,7 @@ Briefly, the file is a simple text format with each row representing one pair of
 FORWARD_PRIMER_SEQ  REVERSE_PRIMER_SEQ  EXPECTED_PRODUCT_SIZE   NAME_OF_PRIMER
 ```
 
-Note that the columns are tab-separated. The expected product size should be roughly correct, but doesn't need to accurate to the base. The primer sequences should represent the exact primer binding sequence. If you use primers with overhanging ends for e.g., downstream ligation, these overhanging ends must not be part of the sequence listed here. Also note that Ptrimmer does not understand degenerate primer sequences. If this is an issue, please use [Cutadapt](#using-cutadapt-instead-of-ptrimmer) instead of Ptrimmer.  
+Note that the columns are tab-separated. The expected product size should be roughly correct, but doesn't need to accurate to the base. The primer sequences should represent the exact primer binding sequence. If you use primers with overhanging ends for e.g., downstream ligation, these overhanging ends must not be part of the sequence listed here. Also note that Ptrimmer does not understand degenerate primer sequences. If this is an issue, please use [Cutadapt](#using-cutadapt-instead-of-ptrimmer) instead of Ptrimmer.
 
 ### `--gene` [default = null]
 
@@ -123,33 +123,33 @@ If you do not use a pre-configured primer set, you will also need to tell the pi
 - nd5
 - nd6
 
-Curated databases for these genes are obtained from [Midori](https://www.reference-midori.info/). 
+Curated databases for these genes are obtained from [Midori](https://www.reference-midori.info/).
 
 ### `--run_name Fubar` [default = null]
 
-A mandatory name for this run, to be included with the result files. 
+A mandatory name for this run, to be included with the result files.
 
 ### `--email me@google.com` [ default = null]
 
-An email address to which the MultiQC report is send after pipeline completion. This requires for the executing system to have [sendmail](https://rimuhosting.com/support/settingupemail.jsp?mta=sendmail) configured. 
+An email address to which the MultiQC report is send after pipeline completion. This requires for the executing system to have [sendmail](https://rimuhosting.com/support/settingupemail.jsp?mta=sendmail) configured.
 
 
 ### `--reference_base` [default = null ]
 
-The location of where the pipeline references are installed on your system. This will typically be pre-set in your site-specific config file and is only needed when you run without one. 
+The location of where the pipeline references are installed on your system. This will typically be pre-set in your site-specific config file and is only needed when you run without one.
 
 This option can be ommitted to trigger an on-the-fly temporary installation in the work directory. This is however not recommended as it creates unecessary traffic for the hoster of the references. See our [installation guide](installation.md) to learn how to install the references permanently on your system.
 
 ### `--outdir results` [default = results]
 
-The location where the results are stored. Usually this will be `results`in the location from where you run the nextflow process. However, this option also accepts any other path in your file system(s). 
+The location where the results are stored. Usually this will be `results`in the location from where you run the nextflow process. However, this option also accepts any other path in your file system(s).
 
 ## Expert options
 
-Only change these if you have a good reason to do so. 
+Only change these if you have a good reason to do so.
 
 ### `--disable_low_complexity [default = false]`
-By default, Blast with filter/main low complexity sequences. If your amplicons have very low complexity, you may wish to set this option to disable the masking of low complexity motifs. 
+By default, Blast with filter/main low complexity sequences. If your amplicons have very low complexity, you may wish to set this option to disable the masking of low complexity motifs.
 
 ```bash
 nextflow run bio-ram/FooDMe2 -profile singularity \\
@@ -158,14 +158,14 @@ nextflow run bio-ram/FooDMe2 -profile singularity \\
 ```
 
 ### `--vsearch_min_cov` [ default = 5 ]
-The minimum amount of coverage required for an OTU to be created from the read data. 
+The minimum amount of coverage required for an OTU to be created from the read data.
 
 ### `--vsearch_cluster_id` [ default = 98 ]
 The percentage similarity for ASUs to be collapsed into OTUs. If you set this to 100, ASUs will not be collapsed at all, which will generate a higher resolution call set at the cost of added noise. In turn, setting this value too low may collapse separate species into "hybrid" OTUs. The default of 98 seems to work quite well for our data, but will occasionally fragment individual taxa into multiple OTUs if sequencing error rate is high. For the TSV output, OTUs with identical taxonimic assignments will be counted as one, whereas the JSON output leaves this step to the user.
 
 ## Using Cutadapt instead of Ptrimmer
 
-Using Cutadapt is discouraged for most users as it requires more configuration and knowledge of your read data. It may thus not yield optimal results in all circumstances. It does however support degenerate primer sequences, which Ptrimmer does not. 
+Using Cutadapt is discouraged for most users as it requires more configuration and knowledge of your read data. It may thus not yield optimal results in all circumstances. It does however support degenerate primer sequences, which Ptrimmer does not.
 
 Some possible usage examples:
 
@@ -176,7 +176,7 @@ nextflow run bio-raum/FooDMe2 -profile standard,conda --input samples.csv \\
 --run_name cutadapt-test
 ```
 
-This example uses a built-in primer set but performs PCR primer site removal with Cutadapt instead of Ptrimmer. 
+This example uses a built-in primer set but performs PCR primer site removal with Cutadapt instead of Ptrimmer.
 
 ```bash
 nextflow run bio-raum/FooDMe2 -profile standard,conda --input samples.csv \\
@@ -186,7 +186,7 @@ nextflow run bio-raum/FooDMe2 -profile standard,conda --input samples.csv \\
 --run_name cutadapt-test
 ```
 
-This example uses your custom primers, performs PCR primer site removal with cutadapt and performs taxonomic profiling against the srrna database. 
+This example uses your custom primers, performs PCR primer site removal with cutadapt and performs taxonomic profiling against the srrna database.
 
 ```bash
 nextflow run bio-raum/FooDMe2 -profile standard,conda --input samples.csv \\
@@ -196,19 +196,19 @@ nextflow run bio-raum/FooDMe2 -profile standard,conda --input samples.csv \\
 --run_name cutadapt-test
 ```
 
-This example will additionally reverse complement your primer sequences and check for primer binding sites at both ends of each read. 
+This example will additionally reverse complement your primer sequences and check for primer binding sites at both ends of each read.
 
 #### `--cutadapt` [ default = false ]
 
-Use Cutadapt instead of Ptrimmer. 
+Use Cutadapt instead of Ptrimmer.
 
 #### `--cutadapt_trim_3p` [ default = false ]
-Use this option if you know that your read length is as long or longer than your PCR product. In this case, the reads will carry both the forward and reverse primer site - something that Cutadapt will normally fail to detect. 
+Use this option if you know that your read length is as long or longer than your PCR product. In this case, the reads will carry both the forward and reverse primer site - something that Cutadapt will normally fail to detect.
 
 #### `--cutadapt_options` [ default = "" ]
-Any additional options you feel should be passed to Cutadapt. Use at your own risk. 
+Any additional options you feel should be passed to Cutadapt. Use at your own risk.
 
 #### `--primers_fa` [ default = null ]
-Your primer sequences in FASTA format. There is no need to provide reverse-complemented sequences here if you wish to use `--cutadapt_trim_3p`, since the pipeline will do that automatically. If the primers in this file contain degenerate bases, the pipeline will automatically disambiguate them. 
+Your primer sequences in FASTA format. There is no need to provide reverse-complemented sequences here if you wish to use `--cutadapt_trim_3p`, since the pipeline will do that automatically. If the primers in this file contain degenerate bases, the pipeline will automatically disambiguate them.
 
-This option requires that you also specify a valid gene name (see above) so that the pipeline knows which database to use for taxonomic profiling. 
+This option requires that you also specify a valid gene name (see above) so that the pipeline knows which database to use for taxonomic profiling.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,7 +80,7 @@ Allowed platforms are:
 
 Note that only Illumina processing is currently enabled - the rest is "coming eventually". The column "platform" is thus optional - if it is not given, "ILLUMINA" is assumed as the default.
 
-### `--primer_set ` [default = null]
+### `--primer_set` [default = null]
 
 The name of the pre-configured primer set to use for read clipping. More sets will be added over time
 
@@ -90,7 +90,7 @@ Available options:
 
 Alternatively, you can specify your own primers as described in the following.
 
-### `--primers_txt ` [ default = null ]
+### `--primers_txt` [ default = null ]
 
 If you wish to use a set of primers not already configured for this pipeline, you can provide it with this option. You will also have to specify which mitochondrial gene this primer set is targeting using the `--gene` option described elsewhere.
 
@@ -102,7 +102,8 @@ Briefly, the file is a simple text format with each row representing one pair of
 FORWARD_PRIMER_SEQ  REVERSE_PRIMER_SEQ  EXPECTED_PRODUCT_SIZE   NAME_OF_PRIMER
 ```
 
-Note that the columns are tab-separated. The expected product size should be roughly correct, but doesn't need to accurate to the base. The primer sequences should represent the exact primer binding sequence. If you use primers with overhanging ends for e.g., downstream ligation, these overhanging ends must not be part of the sequence listed here. Also note that Ptrimmer does not understand degenerate primer sequences. If this is an issue, please use [Cutadapt](#using-cutadapt-instead-of-ptrimmer) instead of Ptrimmer.
+Note that the columns are tab-separated. The expected product size should be roughly correct, but doesn't need to accurate to the base. The primer sequences should represent the exact primer binding sequence.
+If you use primers with overhanging ends for e.g., downstream ligation, these overhanging ends must not be part of the sequence listed here. Also note that Ptrimmer does not understand degenerate primer sequences. If this is an issue, please use [Cutadapt](#using-cutadapt-instead-of-ptrimmer) instead of Ptrimmer.
 
 ### `--gene` [default = null]
 
@@ -161,7 +162,8 @@ nextflow run bio-ram/FooDMe2 -profile singularity \\
 The minimum amount of coverage required for an OTU to be created from the read data.
 
 ### `--vsearch_cluster_id` [ default = 98 ]
-The percentage similarity for ASUs to be collapsed into OTUs. If you set this to 100, ASUs will not be collapsed at all, which will generate a higher resolution call set at the cost of added noise. In turn, setting this value too low may collapse separate species into "hybrid" OTUs. The default of 98 seems to work quite well for our data, but will occasionally fragment individual taxa into multiple OTUs if sequencing error rate is high. For the TSV output, OTUs with identical taxonimic assignments will be counted as one, whereas the JSON output leaves this step to the user.
+The percentage similarity for ASUs to be collapsed into OTUs. If you set this to 100, ASUs will not be collapsed at all, which will generate a higher resolution call set at the cost of added noise. In turn, setting this value too low may collapse separate species into "hybrid" OTUs.
+The default of 98 seems to work quite well for our data, but will occasionally fragment individual taxa into multiple OTUs if sequencing error rate is high. For the TSV output, OTUs with identical taxonimic assignments will be counted as one, whereas the JSON output leaves this step to the user.
 
 ## Using Cutadapt instead of Ptrimmer
 
@@ -198,17 +200,17 @@ nextflow run bio-raum/FooDMe2 -profile standard,conda --input samples.csv \\
 
 This example will additionally reverse complement your primer sequences and check for primer binding sites at both ends of each read.
 
-#### `--cutadapt` [ default = false ]
+### `--cutadapt` [ default = false ]
 
 Use Cutadapt instead of Ptrimmer.
 
-#### `--cutadapt_trim_3p` [ default = false ]
+### `--cutadapt_trim_3p` [ default = false ]
 Use this option if you know that your read length is as long or longer than your PCR product. In this case, the reads will carry both the forward and reverse primer site - something that Cutadapt will normally fail to detect.
 
-#### `--cutadapt_options` [ default = "" ]
+### `--cutadapt_options` [ default = "" ]
 Any additional options you feel should be passed to Cutadapt. Use at your own risk.
 
-#### `--primers_fa` [ default = null ]
+### `--primers_fa` [ default = null ]
 Your primer sequences in FASTA format. There is no need to provide reverse-complemented sequences here if you wish to use `--cutadapt_trim_3p`, since the pipeline will do that automatically. If the primers in this file contain degenerate bases, the pipeline will automatically disambiguate them.
 
 This option requires that you also specify a valid gene name (see above) so that the pipeline knows which database to use for taxonomic profiling.


### PR DESCRIPTION
Replaces Groovy-linter with Superlinter to include all other code:
- Python
- YAML/JSON
- R
- Markdown
- Bash 
- Perl
- Groovy

Other languages can be added in the YAML action file.

Fixed Markdown linting
Python linter is going crazy over the snakemakes statements, this will be fixed progressively in #2 
Still one Groovy Error  `/github/workspace/subworkflows/illumina_workflow/main.nf: 45 This code cannot be reached  DeadCode`