### PR TITLE
FIX: uid issue caused by tar in rootless podman profile

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -96,5 +96,11 @@ process {
     //         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     //     ]
     // }
+    withName: UNTAR_TAXONOMY {
+        ext.args = '--no-same-owner'
+    }
+    withName: UNTAR_NCBI {
+        ext.args = '--no-same-owner'
+    }
 
 }

--- a/modules/untar/main.nf
+++ b/modules/untar/main.nf
@@ -31,15 +31,15 @@ process UNTAR {
     if [[ \$(tar -taf ${archive} | grep -o -P "^.*?\\/" | uniq | wc -l) -eq 1 ]]; then
         tar \\
             -C $prefix --strip-components 1 \\
-            -xavf \\
             $args \\
+            -xavf \\
             $archive \\
             $args2
     else
         tar \\
             -C $prefix \\
-            -xavf \\
             $args \\
+            -xavf \\
             $archive \\
             $args2
     fi


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation
- [ ] New Release

**Only new release type PRs are allowed on the `main` branch. All other PR should target the `dev`branch.**

## Description

We are running your workflow with podman containers on our local SLURM-Cluster, which seems to work except for the
`build_refs` workflow. The workflow fails at `UNTAR` process stages with this error message:
```
Command error:
  tar: taxdb.btd: Cannot change ownership to uid 9011, gid 990: Operation not permitted
  tar: taxdb.bti: Cannot change ownership to uid 9011, gid 990: Operation not permitted
  tar: taxonomy4blast.sqlite3: Cannot change ownership to uid 9011, gid 990: Operation not permitted
  tar: Exiting with failure status due to previous errors
```

The issue comes from the rootless-podman execution, and tar trying to automatically change ownership of files/directories to preserve the metadata of files just unpacked. I suggest to use the `--no-same-owner` flag for tar to prevent this.

Honestly, I have no idea how this would impact other profiles and wheter or not you intended to have the ownership of the files preserved. However, while I added this parameter in the (hopefully right place) config files, it turned out, that `$args` is misplaced in `UNTAR` process, because it is used before `$archive`, which makes tar interprete `$args` as files (coming right after the `f` of `xavf`).

## Related issues and discussions

I did not open an issue and thought it might be helpful to directly see the suggested changes. Feel free to turn it down or fix this issue in a different way.

## Tests

Both `main` and `build_ref` workflow are perfectly functional on our system with this minor change.

## Updated the documentation?

- [ ] Yes
- [X] No, and this is why: minor bugfix, the documentation should not be affected